### PR TITLE
Fixing multi line messages by fixing the regex

### DIFF
--- a/WickrIOBot.js
+++ b/WickrIOBot.js
@@ -217,11 +217,12 @@ class WickrIOBot {
     if (message.control)
       return;
     else
-      var parsedData = request.match(/(\/[a-zA-Z]+)(@[a-zA-Z0-9_-]+)?(\s+)?(.*)$/);
+      //This doesn't capture @ mentions
+      var parsedData = request.match(/(\/[a-zA-Z]+)([\s\S]*)$/);
     if (parsedData !== null) {
       command = parsedData[1];
-      if (parsedData[4] !== '') {
-        argument = parsedData[4];
+      if (parsedData[2] !== '') {
+        argument = parsedData[2];
       }
     }
     if (vGroupID.charAt(0) === 'a' || vGroupID.charAt(0) === 'c' || vGroupID.charAt(0) === 'd')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickrio-bot-api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The official Wickr IO Bot API Framework",
   "main": "WickrIOBot.js",
   "dependencies": {


### PR DESCRIPTION
This will allow bots to send multi line messages. Regex can be improved if necessary in the future but works for what we need.