### PR TITLE
  Fixed admin remove and add bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickrio-bot-api",
-  "version": "5.64.2",
+  "version": "5.64.3",
   "description": "The official Wickr IO Bot API Framework",
   "main": "src/WickrIOBot.js",
   "dependencies": {

--- a/src/WickrAdmin.js
+++ b/src/WickrAdmin.js
@@ -107,6 +107,7 @@ class WickrAdmin {
         // Process the list of users to be added from the white list
         var values = action.split(' ')
         values.shift()
+        values = this.removeDuplicates(values)
         var addFails = []
         if (values.length >= 1) {
           for (var i = 0; i < values.length; i++) {
@@ -152,6 +153,7 @@ class WickrAdmin {
         // TODO potentially add buttons here?
         var values = action.split(' ')
         values.shift()
+        values = this.removeDuplicates(values)
         var removeFails = []
         if (values.length >= 1) {
           for (var i = 0; i < values.length; i++) {
@@ -283,6 +285,17 @@ class WickrAdmin {
       return strings['adminHelp']
     }
   }
+
+    // Function to remove duplicate values from a list of users
+    removeDuplicates(userList) {
+      const uniqueUsers = []
+      for (let user = 0; user < userList.length; user += 1) {
+        if (!uniqueUsers.includes(userList[user])) {
+          uniqueUsers.push(userList[user])
+        }
+      }
+      return uniqueUsers
+    }
 }
 
 module.exports = WickrAdmin


### PR DESCRIPTION
- If an admin attempts to add a user to the admin list multiple times with one command ex. "/admin add user1 user1 user1" that user will only be added into the admin list one time.

- Previously before this bug fix if an admin sent a command like "/admin remove user1 user1 user1" the correct user would be removed but 2 other random users would also be removed. After this bug fix only the correct admin will be removed from the admin list if that same command was sent. 