### PR TITLE
fix: add prompt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "wickrio-bot-api",
-  "version": "6.34.1",
+  "version": "6.34.2",
   "description": "The official Wickr IO Bot API Framework",
   "main": "src/WickrIOBot.js",
   "dependencies": {
     "dotenv": "^8.2.0",
     "fs": "0.0.2",
+    "prompt": "^1.3.0",
     "simple-encryptor": "^3.0.0",
     "wickrio_addon": "6.34.x",
     "winston": "^3.3.3",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This package depends on `prompt`, but it isn't specified in package.json so all dependent packages are required to install it. Fix that by specifying it in the dependencies here.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
